### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: CI
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/WebDevelopment761/MindWrite/security/code-scanning/1](https://github.com/WebDevelopment761/MindWrite/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions for the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the current workflow's functionality. This change ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
